### PR TITLE
Fixed tsconfig to add types when publishing the package 

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,3 +1,3 @@
-import TwoPi from "./twoPi";
+import TwoPi from './twoPi'
 
-export { TwoPi };
+export { TwoPi }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,1 +1,3 @@
-export const TwoPi = require('./twoPi').default
+import TwoPi from "./twoPi";
+
+export { TwoPi };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "rootDir": "ts",
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "rootDir": "ts",
     "outDir": "dist",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": true
   }
 }


### PR DESCRIPTION
Added `declaration` and `declarationMap` to `tsconfig.json` to allow exporting the typescript types of the package when publishing it to npm.